### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,21 @@
+name: Clojure CI
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: lein deps
+    - name: Run tests
+      run: lein test


### PR DESCRIPTION
People are starting to switch to Github Actions for CI -- it's reportedly configurable as text within the repo, is sometimes quicker than Travis, and has obvious nice UI integration