### PR TITLE
Add SQL examples, adjust input syntax to be consistent

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -37,7 +37,8 @@ They can be configured this way:
   - Rustup (install Rust compiler, Cargo, etc.)
     MacOS: `brew uninstall rust` `brew install rustup` `rustup-init`
     and start a new terminal session
-  - Java JDK (OpenJDK seems fine, no version constraint known yet) 
+  - Java JDK (OpenJDK seems fine, no version constraint known yet)
+  - For compiling/running Java via gradle, set `JAVA_HOME` environment variable to your default Java version path ([how to find Java version on macOS](https://stackoverflow.com/questions/36766028/see-all-the-java-versions-installed-on-mac)) 
   - `clojure` command-line tool (from the [official Clojure distribution](https://clojure.org/guides/getting_started),
     ex: `brew install clojure/tools/clojure` on macOS)
   - [Leiningen](https://leiningen.org/) for running unit tests (ex: locally and in CI) 

--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -38,6 +38,14 @@ abstract concepts of size. Specifically, integer size = a Java integer = 32-bit 
   Java integers return integer sizes of collections, strings, etc. A language like Rust uses `usize`
   for a platform dependent size, which must be cast to `i32`, `u32`, `i64`, `u64`, etc. to match the
   type specified by the user's input code.
+  
+### Keywords
+
+* Keywords are treated as strings in the target language.
+We can't use them as functions nor check whether a value is a keyword using `keyword?`.
+* The decision is based on the lack of benefit in the target languages, especially in a context of transpiling to the target languages.
+Keywords had/have 2 main benefits in Clojure: 1) interning so that only a single instance is stored, and 2) using keywords as functions (mainly for lookups in first position, but also for HOFs (ex: `map`).
+  But subsequent versions of Java now intern string literals, and the functions-in-first-position syntax only benefits Clojure/Lisp.
 
 ### Switch / Match
 

--- a/examples/rust/src/a/demo_01.rs
+++ b/examples/rust/src/a/demo_01.rs
@@ -21,7 +21,7 @@ pub fn format(num: i32) -> String {
     }
 }
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         format(2345);
         println!("{}", format(2345));

--- a/examples/rust/src/a/demo_02.rs
+++ b/examples/rust/src/a/demo_02.rs
@@ -218,7 +218,7 @@ pub fn format(num: i32, number_system: String, grouping_strategy: String) -> Str
     }
 }
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         println!("{}", parse(String::from("٥٠٣٠١")));
         println!("{}", parse(String::from("৫০৩০১")));

--- a/examples/rust/src/a/demo_03.rs
+++ b/examples/rust/src/a/demo_03.rs
@@ -1,6 +1,6 @@
 use crate::kalai;
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         println!("{}", std::env::var(String::from("USER")).unwrap());
     }

--- a/examples/rust/src/b/loops.rs
+++ b/examples/rust/src/b/loops.rs
@@ -1,6 +1,6 @@
 use crate::kalai;
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         let mut i: i64 = 0;
         while (i < 10) {

--- a/examples/rust/src/b/requirer.rs
+++ b/examples/rust/src/b/requirer.rs
@@ -1,6 +1,6 @@
 use crate::kalai;
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         println!("{}", crate::b::required::f(1));
     }

--- a/examples/rust/src/b/simple.rs
+++ b/examples/rust/src/b/simple.rs
@@ -3,7 +3,7 @@ pub fn add(a: i64, b: i64) -> i64 {
     return (a + b);
 }
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         println!("{}", add(1, 2));
     }

--- a/examples/rust/src/b/type_alias.rs
+++ b/examples/rust/src/b/type_alias.rs
@@ -10,7 +10,7 @@ pub fn f(y: std::collections::HashMap<i64, String>) -> std::collections::HashMap
     return z;
 }
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         println!("{}", String::from("OK"));
     }

--- a/examples/rust/src/b/variable.rs
+++ b/examples/rust/src/b/variable.rs
@@ -8,7 +8,7 @@ pub fn side_effect() -> i64 {
     }
 }
 pub fn main() {
-    let args: std::vec::Vec<String> = std::env::args().collect();
+    let _args: std::vec::Vec<String> = std::env::args().collect();
     {
         println!("{}", side_effect());
     }

--- a/sql_builder/Makefile
+++ b/sql_builder/Makefile
@@ -1,5 +1,7 @@
-.PHONY: build clean setup transpile rust java
-all: build
+.PHONY: all run_all build clean setup transpile rust java run_rust run_java
+all: build run_all
+
+run_all: run_rust run_java
 
 clean:
 	rm -rf java/src java/build
@@ -24,3 +26,9 @@ rust:
 
 java:
 	cd java && gradle build
+
+run_rust:
+	cd rust && cargo run sql_builder_run_examples
+
+run_java:
+	cd java/build/classes/java/main/ && java sqlbuilder.Examples

--- a/sql_builder/README.md
+++ b/sql_builder/README.md
@@ -1,0 +1,9 @@
+## Notes:
+
+Divergences of sql_builder input syntax from Honey SQL syntax:
+
+* Use strings instead of keywords
+* Quote your own string literals
+* FROM clause table name values should match the SELECT clause column values.
+In other words, use a vector inside the vector when aliasing a table name, just as you would for aliasing column names.
+  

--- a/sql_builder/java/src/sqlbuilder/Core.java
+++ b/sql_builder/java/src/sqlbuilder/Core.java
@@ -7,7 +7,16 @@ import java.util.stream.Collectors;
 
 public class Core {
   public static final String castToStr(final Object x) {
-    return (String) x;
+    if ((x instanceof List)) {
+      final ArrayList<Object> v = (ArrayList) x;
+      final Object vFirst = v.get(0);
+      final String tableName = (String) vFirst;
+      final Object vSecond = v.get(1);
+      final String tableAlias = (String) vSecond;
+      return ("" + tableName + " as " + tableAlias);
+    } else {
+      return (String) x;
+    }
   }
 
   public static final String selectStr(final ArrayList<Object> select) {

--- a/sql_builder/java/src/sqlbuilder/Core.java
+++ b/sql_builder/java/src/sqlbuilder/Core.java
@@ -13,7 +13,7 @@ public class Core {
       final String tableName = (String) vFirst;
       final Object vSecond = v.get(1);
       final String tableAlias = (String) vSecond;
-      return ("" + tableName + " as " + tableAlias);
+      return ("" + tableName + " AS " + tableAlias);
     } else {
       return (String) x;
     }

--- a/sql_builder/java/src/sqlbuilder/Examples.java
+++ b/sql_builder/java/src/sqlbuilder/Examples.java
@@ -7,19 +7,24 @@ public class Examples {
   public static final String f1() {
     HashMap<String, Object> tmp1 = new HashMap<String, Object>();
     ArrayList<Object> tmp2 = new ArrayList<Object>();
-    tmp2.add(":foo");
+    tmp2.add("foo");
     tmp1.put(":from", tmp2);
     ArrayList<Object> tmp3 = new ArrayList<Object>();
-    tmp3.add(":a");
-    tmp3.add(":b");
-    tmp3.add(":c");
+    tmp3.add("a");
+    tmp3.add("b");
+    tmp3.add("c");
     tmp1.put(":select", tmp3);
     ArrayList<Object> tmp4 = new ArrayList<Object>();
-    tmp4.add(":=");
-    tmp4.add(":f.a");
+    tmp4.add("=");
+    tmp4.add("f.a");
     tmp4.add("baz");
     tmp1.put(":where", tmp4);
     final HashMap<String, Object> queryMap = tmp1;
     return sqlbuilder.Core.format(queryMap);
+  }
+
+  public static final void main(String[] args) {
+    final String queryStr = sqlbuilder.Examples.f1();
+    System.out.println(("" + "example query string: [" + queryStr + "]"));
   }
 }

--- a/sql_builder/java/src/sqlbuilder/Examples.java
+++ b/sql_builder/java/src/sqlbuilder/Examples.java
@@ -17,14 +17,86 @@ public class Examples {
     ArrayList<Object> tmp4 = new ArrayList<Object>();
     tmp4.add("=");
     tmp4.add("f.a");
-    tmp4.add("baz");
+    tmp4.add("'baz'");
     tmp1.put(":where", tmp4);
     final HashMap<String, Object> queryMap = tmp1;
     return sqlbuilder.Core.format(queryMap);
   }
 
+  public static final String f2() {
+    HashMap<String, Object> tmp5 = new HashMap<String, Object>();
+    ArrayList<Object> tmp6 = new ArrayList<Object>();
+    tmp6.add("foo");
+    tmp5.put(":from", tmp6);
+    ArrayList<Object> tmp7 = new ArrayList<Object>();
+    tmp7.add("*");
+    tmp5.put(":select", tmp7);
+    ArrayList<Object> tmp8 = new ArrayList<Object>();
+    tmp8.add("AND");
+    ArrayList<Object> tmp9 = new ArrayList<Object>();
+    tmp9.add("=");
+    tmp9.add("a");
+    tmp9.add("1");
+    tmp8.add(tmp9);
+    ArrayList<Object> tmp10 = new ArrayList<Object>();
+    tmp10.add("<");
+    tmp10.add("b");
+    tmp10.add("100");
+    tmp8.add(tmp10);
+    tmp5.put(":where", tmp8);
+    final HashMap<String, Object> queryMap = tmp5;
+    return sqlbuilder.Core.format(queryMap);
+  }
+
+  public static final String f3() {
+    HashMap<String, Object> tmp11 = new HashMap<String, Object>();
+    ArrayList<Object> tmp12 = new ArrayList<Object>();
+    ArrayList<Object> tmp13 = new ArrayList<Object>();
+    tmp13.add("foo");
+    tmp13.add("quux");
+    tmp12.add(tmp13);
+    tmp11.put(":from", tmp12);
+    ArrayList<Object> tmp14 = new ArrayList<Object>();
+    tmp14.add("a");
+    ArrayList<Object> tmp15 = new ArrayList<Object>();
+    tmp15.add("b");
+    tmp15.add("bar");
+    tmp14.add(tmp15);
+    tmp14.add("c");
+    ArrayList<Object> tmp16 = new ArrayList<Object>();
+    tmp16.add("d");
+    tmp16.add("x");
+    tmp14.add(tmp16);
+    tmp11.put(":select", tmp14);
+    ArrayList<Object> tmp17 = new ArrayList<Object>();
+    tmp17.add("AND");
+    ArrayList<Object> tmp18 = new ArrayList<Object>();
+    tmp18.add("=");
+    tmp18.add("quux.a");
+    tmp18.add("1");
+    tmp17.add(tmp18);
+    ArrayList<Object> tmp19 = new ArrayList<Object>();
+    tmp19.add("<");
+    tmp19.add("bar");
+    tmp19.add("100");
+    tmp17.add(tmp19);
+    tmp11.put(":where", tmp17);
+    final HashMap<String, Object> queryMap = tmp11;
+    return sqlbuilder.Core.format(queryMap);
+  }
+
   public static final void main(String[] args) {
-    final String queryStr = sqlbuilder.Examples.f1();
-    System.out.println(("" + "example query string: [" + queryStr + "]"));
+    {
+      final String queryStr = sqlbuilder.Examples.f1();
+      System.out.println(("" + "example 1 query string: [" + queryStr + "]"));
+    }
+    {
+      final String queryStr = sqlbuilder.Examples.f2();
+      System.out.println(("" + "example 2 query string: [" + queryStr + "]"));
+    }
+    {
+      final String queryStr = sqlbuilder.Examples.f3();
+      System.out.println(("" + "example 2 query string: [" + queryStr + "]"));
+    }
   }
 }

--- a/sql_builder/rust/src/sql_builder/core.rs
+++ b/sql_builder/rust/src/sql_builder/core.rs
@@ -1,6 +1,15 @@
 use crate::kalai;
 pub fn cast_to_str(x: kalai::Value) -> String {
-    return kalai::to_string(x.clone());
+    if kalai::is_vector(x.clone()) {
+        let v: std::vec::Vec<kalai::Value> = kalai::to_mvector(x.clone());
+        let v_first: kalai::Value = v.get(0 as usize).unwrap().clone();
+        let table_name: String = kalai::to_string(v_first.clone());
+        let v_second: kalai::Value = v.get(1 as usize).unwrap().clone();
+        let table_alias: String = kalai::to_string(v_second.clone());
+        return format!("{}{}{}", table_name, String::from(" as "), table_alias);
+    } else {
+        return kalai::to_string(x.clone());
+    }
 }
 pub fn select_str(select: std::vec::Vec<kalai::Value>) -> String {
     return select

--- a/sql_builder/rust/src/sql_builder/core.rs
+++ b/sql_builder/rust/src/sql_builder/core.rs
@@ -6,7 +6,7 @@ pub fn cast_to_str(x: kalai::Value) -> String {
         let table_name: String = kalai::to_string(v_first.clone());
         let v_second: kalai::Value = v.get(1 as usize).unwrap().clone();
         let table_alias: String = kalai::to_string(v_second.clone());
-        return format!("{}{}{}", table_name, String::from(" as "), table_alias);
+        return format!("{}{}{}", table_name, String::from(" AS "), table_alias);
     } else {
         return kalai::to_string(x.clone());
     }

--- a/sql_builder/rust/src/sql_builder/examples.rs
+++ b/sql_builder/rust/src/sql_builder/examples.rs
@@ -8,7 +8,7 @@ pub fn f_1() -> String {
             kalai::Value::MVector(
                 {
                     let mut tmp_2: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
-                    tmp_2.push(kalai::Value::String(String::from(":foo")));
+                    tmp_2.push(kalai::Value::String(String::from("foo")));
                     tmp_2
                 }
                 .clone(),
@@ -19,9 +19,9 @@ pub fn f_1() -> String {
             kalai::Value::MVector(
                 {
                     let mut tmp_3: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
-                    tmp_3.push(kalai::Value::String(String::from(":a")));
-                    tmp_3.push(kalai::Value::String(String::from(":b")));
-                    tmp_3.push(kalai::Value::String(String::from(":c")));
+                    tmp_3.push(kalai::Value::String(String::from("a")));
+                    tmp_3.push(kalai::Value::String(String::from("b")));
+                    tmp_3.push(kalai::Value::String(String::from("c")));
                     tmp_3
                 }
                 .clone(),
@@ -32,8 +32,8 @@ pub fn f_1() -> String {
             kalai::Value::MVector(
                 {
                     let mut tmp_4: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
-                    tmp_4.push(kalai::Value::String(String::from(":=")));
-                    tmp_4.push(kalai::Value::String(String::from(":f.a")));
+                    tmp_4.push(kalai::Value::String(String::from("=")));
+                    tmp_4.push(kalai::Value::String(String::from("f.a")));
                     tmp_4.push(kalai::Value::String(String::from("baz")));
                     tmp_4
                 }
@@ -43,4 +43,19 @@ pub fn f_1() -> String {
         tmp_1
     };
     return crate::sql_builder::core::format(query_map);
+}
+pub fn main() {
+    let _args: std::vec::Vec<String> = std::env::args().collect();
+    {
+        let query_str: String = f_1();
+        println!(
+            "{}",
+            format!(
+                "{}{}{}",
+                String::from("example query string: ["),
+                query_str,
+                String::from("]")
+            )
+        );
+    }
 }

--- a/sql_builder/rust/src/sql_builder/examples.rs
+++ b/sql_builder/rust/src/sql_builder/examples.rs
@@ -34,7 +34,7 @@ pub fn f_1() -> String {
                     let mut tmp_4: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
                     tmp_4.push(kalai::Value::String(String::from("=")));
                     tmp_4.push(kalai::Value::String(String::from("f.a")));
-                    tmp_4.push(kalai::Value::String(String::from("baz")));
+                    tmp_4.push(kalai::Value::String(String::from("'baz'")));
                     tmp_4
                 }
                 .clone(),
@@ -44,18 +44,193 @@ pub fn f_1() -> String {
     };
     return crate::sql_builder::core::format(query_map);
 }
+pub fn f_2() -> String {
+    let query_map: std::collections::HashMap<String, kalai::Value> = {
+        let mut tmp_5: std::collections::HashMap<String, kalai::Value> =
+            std::collections::HashMap::new();
+        tmp_5.insert(
+            String::from(":from"),
+            kalai::Value::MVector(
+                {
+                    let mut tmp_6: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                    tmp_6.push(kalai::Value::String(String::from("foo")));
+                    tmp_6
+                }
+                .clone(),
+            ),
+        );
+        tmp_5.insert(
+            String::from(":select"),
+            kalai::Value::MVector(
+                {
+                    let mut tmp_7: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                    tmp_7.push(kalai::Value::String(String::from("*")));
+                    tmp_7
+                }
+                .clone(),
+            ),
+        );
+        tmp_5.insert(
+            String::from(":where"),
+            kalai::Value::MVector(
+                {
+                    let mut tmp_8: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                    tmp_8.push(kalai::Value::String(String::from("AND")));
+                    tmp_8.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_9: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_9.push(kalai::Value::String(String::from("=")));
+                            tmp_9.push(kalai::Value::String(String::from("a")));
+                            tmp_9.push(kalai::Value::String(String::from("1")));
+                            tmp_9
+                        }
+                        .clone(),
+                    ));
+                    tmp_8.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_10: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_10.push(kalai::Value::String(String::from("<")));
+                            tmp_10.push(kalai::Value::String(String::from("b")));
+                            tmp_10.push(kalai::Value::String(String::from("100")));
+                            tmp_10
+                        }
+                        .clone(),
+                    ));
+                    tmp_8
+                }
+                .clone(),
+            ),
+        );
+        tmp_5
+    };
+    return crate::sql_builder::core::format(query_map);
+}
+pub fn f_3() -> String {
+    let query_map: std::collections::HashMap<String, kalai::Value> = {
+        let mut tmp_11: std::collections::HashMap<String, kalai::Value> =
+            std::collections::HashMap::new();
+        tmp_11.insert(
+            String::from(":from"),
+            kalai::Value::MVector(
+                {
+                    let mut tmp_12: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                    tmp_12.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_13: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_13.push(kalai::Value::String(String::from("foo")));
+                            tmp_13.push(kalai::Value::String(String::from("quux")));
+                            tmp_13
+                        }
+                        .clone(),
+                    ));
+                    tmp_12
+                }
+                .clone(),
+            ),
+        );
+        tmp_11.insert(
+            String::from(":select"),
+            kalai::Value::MVector(
+                {
+                    let mut tmp_14: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                    tmp_14.push(kalai::Value::String(String::from("a")));
+                    tmp_14.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_15: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_15.push(kalai::Value::String(String::from("b")));
+                            tmp_15.push(kalai::Value::String(String::from("bar")));
+                            tmp_15
+                        }
+                        .clone(),
+                    ));
+                    tmp_14.push(kalai::Value::String(String::from("c")));
+                    tmp_14.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_16: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_16.push(kalai::Value::String(String::from("d")));
+                            tmp_16.push(kalai::Value::String(String::from("x")));
+                            tmp_16
+                        }
+                        .clone(),
+                    ));
+                    tmp_14
+                }
+                .clone(),
+            ),
+        );
+        tmp_11.insert(
+            String::from(":where"),
+            kalai::Value::MVector(
+                {
+                    let mut tmp_17: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                    tmp_17.push(kalai::Value::String(String::from("AND")));
+                    tmp_17.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_18: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_18.push(kalai::Value::String(String::from("=")));
+                            tmp_18.push(kalai::Value::String(String::from("quux.a")));
+                            tmp_18.push(kalai::Value::String(String::from("1")));
+                            tmp_18
+                        }
+                        .clone(),
+                    ));
+                    tmp_17.push(kalai::Value::MVector(
+                        {
+                            let mut tmp_19: std::vec::Vec<kalai::Value> = std::vec::Vec::new();
+                            tmp_19.push(kalai::Value::String(String::from("<")));
+                            tmp_19.push(kalai::Value::String(String::from("bar")));
+                            tmp_19.push(kalai::Value::String(String::from("100")));
+                            tmp_19
+                        }
+                        .clone(),
+                    ));
+                    tmp_17
+                }
+                .clone(),
+            ),
+        );
+        tmp_11
+    };
+    return crate::sql_builder::core::format(query_map);
+}
 pub fn main() {
     let _args: std::vec::Vec<String> = std::env::args().collect();
     {
-        let query_str: String = f_1();
-        println!(
-            "{}",
-            format!(
-                "{}{}{}",
-                String::from("example query string: ["),
-                query_str,
-                String::from("]")
-            )
-        );
+        {
+            let query_str: String = f_1();
+            println!(
+                "{}",
+                format!(
+                    "{}{}{}",
+                    String::from("example 1 query string: ["),
+                    query_str,
+                    String::from("]")
+                )
+            );
+        }
+        {
+            let query_str: String = f_2();
+            println!(
+                "{}",
+                format!(
+                    "{}{}{}",
+                    String::from("example 2 query string: ["),
+                    query_str,
+                    String::from("]")
+                )
+            );
+        }
+        {
+            let query_str: String = f_3();
+            println!(
+                "{}",
+                format!(
+                    "{}{}{}",
+                    String::from("example 2 query string: ["),
+                    query_str,
+                    String::from("]")
+                )
+            );
+        }
     }
 }

--- a/sql_builder/rust/src_bin/main.rs
+++ b/sql_builder/rust/src_bin/main.rs
@@ -1,4 +1,3 @@
 pub fn main() {
-    let query_str: String = sql_builder::sql_builder::examples::f_1();
-    println!("example query string: [{}]", query_str);
+    sql_builder::sql_builder::examples::main();
 }

--- a/sql_builder/src/sql_builder/core.clj
+++ b/sql_builder/src/sql_builder/core.clj
@@ -3,7 +3,14 @@
   (:require [clojure.string :as str]))
 
 (defn cast-to-str ^{:t :string} [^{:t :any} x]
-  ^{:cast :string} x)
+  (if (vector? x)
+    (let [^{:t {:mvector [:any]}} v ^{:cast :mvector} x
+          ^{:t :any} v-first (nth v (int 0))
+          ^{:t :string} table-name ^{:cast :string} v-first
+          ^{:t :any} v-second (nth v (int 1))
+          ^{:t :string} table-alias ^{:cast :string} v-second]
+      (str table-name " AS " table-alias))
+    ^{:cast :string} x))
 
 (defn select-str ^{:t :string} [^{:t {:mvector [:any]}} select]
   (str/join ", " (map cast-to-str (seq select))))
@@ -19,10 +26,7 @@
   (if (vector? clause)
     (let [^{:t {:mvector [:any]}} v ^{:cast :mvector} clause
           ^{:t :any} v-first (first (seq v))
-          ^{:t :string} op ^{:cast :string} v-first
-          ;;more (next (seq v))
-          ;;[op & more] v
-          ]
+          ^{:t :string} op ^{:cast :string} v-first]
       (str "("
            (str/join (str " " op " ")
                      (map where-str (next (seq v))))

--- a/sql_builder/src/sql_builder/examples.clj
+++ b/sql_builder/src/sql_builder/examples.clj
@@ -2,7 +2,14 @@
   (:require [sql-builder.core :as sql]))
 
 (defn f1 ^{:t :string} []
-  (let [^{:t {:mmap [:string :any]}} query-map {:select ^{:t {:mvector [:any]}} [:a :b :c]
-                                                :from   ^{:t {:mvector [:any]}} [:foo]
-                                                :where  ^{:t {:mvector [:any]}} [:= :f.a "baz"]}]
+  (let [^{:t {:mmap [:string :any]}} query-map {:select ^{:t {:mvector [:any]}} ["a" "b" "c"]
+                                                :from   ^{:t {:mvector [:any]}} ["foo"]
+                                                :where  ^{:t {:mvector [:any]}} ["=" "f.a" "baz"]}]
     (sql/format query-map)))
+
+
+(defn -main ^{:t :void} [& _args]
+  (let [^String query-str (f1)]
+    (println (str "example query string: ["
+                  query-str
+                  "]"))))

--- a/sql_builder/src/sql_builder/examples.clj
+++ b/sql_builder/src/sql_builder/examples.clj
@@ -4,12 +4,33 @@
 (defn f1 ^{:t :string} []
   (let [^{:t {:mmap [:string :any]}} query-map {:select ^{:t {:mvector [:any]}} ["a" "b" "c"]
                                                 :from   ^{:t {:mvector [:any]}} ["foo"]
-                                                :where  ^{:t {:mvector [:any]}} ["=" "f.a" "baz"]}]
+                                                :where  ^{:t {:mvector [:any]}} ["=" "f.a" "'baz'"]}]
+    (sql/format query-map)))
+
+(defn f2 ^{:t :string} []
+  (let [^{:t {:mmap [:string :any]}} query-map {:select ^{:t {:mvector [:any]}} ["*"]
+                                                :from   ^{:t {:mvector [:any]}} ["foo"]
+                                                :where  ^{:t {:mvector [:any]}} ["AND"
+                                                                                 ^{:t {:mvector [:any]}} ["=" "a" "1"]
+                                                                                 ^{:t {:mvector [:any]}} ["<" "b" "100"]]}]
+    (sql/format query-map)))
+
+(defn f3 ^{:t :string} []
+  (let [^{:t {:mmap [:string :any]}} query-map {:select ^{:t {:mvector [:any]}} ["a"
+                                                                                 ^{:t {:mvector [:any]}} ["b" "bar"]
+                                                                                 "c"
+                                                                                 ^{:t {:mvector [:any]}} ["d" "x"]]
+                                                :from   ^{:t {:mvector [:any]}} [^{:t {:mvector [:any]}} ["foo" "quux"]]
+                                                :where  ^{:t {:mvector [:any]}} ["AND"
+                                                                                 ^{:t {:mvector [:any]}} ["=" "quux.a" "1"]
+                                                                                 ^{:t {:mvector [:any]}} ["<" "bar" "100"]]}]
     (sql/format query-map)))
 
 
 (defn -main ^{:t :void} [& _args]
   (let [^String query-str (f1)]
-    (println (str "example query string: ["
-                  query-str
-                  "]"))))
+    (println (str "example 1 query string: [" query-str "]")))
+  (let [^String query-str (f2)]
+    (println (str "example 2 query string: [" query-str "]")))
+  (let [^String query-str (f3)]
+    (println (str "example 2 query string: [" query-str "]"))))


### PR DESCRIPTION
Syntax (structure) of input maps deviates from Honey SQL to be more consistent (FROM clause aliases) and to make it easier to support transpiler target language output (use strings instead of keywords).